### PR TITLE
Replace $HOME with ~ only at the beginning of displayed paths

### DIFF
--- a/functions/nvm.fish
+++ b/functions/nvm.fish
@@ -171,7 +171,7 @@ function nvm --description "Node version manager"
                 return 1
             end
 
-            set --query silent || printf "Uninstalling Node %s %s\n" $ver (string replace ~ \~ "$nvm_data/$ver/bin/node")
+            set --query silent || printf "Uninstalling Node %s %s\n" $ver (string replace -r "^$HOME" '~' "$nvm_data/$ver/bin/node")
 
             _nvm_version_deactivate $ver
 
@@ -233,5 +233,5 @@ function _nvm_node_info
         console.log(process.version)
         console.log('$npm_version_default' ? '$npm_version_default': require('$npm_path/package.json').version)
         console.log(process.execPath)
-    " | string replace -- ~ \~
+    " | string replace -r -a -- "(^|\s)$HOME" '\1~'
 end


### PR DESCRIPTION
Avoid displaying weird messages with ~ in the middle of it, e.g.:

> Now using Node v22.15.1 (npm 10.9.2) /var~/.local/share/nvm/v22.15.1/bin/node

when `HOME=/home/user/` and node was installed in `/var/home/user/.local/share/nvm/`

This shows up on Fedora atomic desktop where `/home` is a symlink to `/var/home` but users' home dirs are set to `/home/$USER`.