### PR TITLE
Add nvm enable corepack variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
-on: push
+on:
+  - push
+  - pull_request
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -111,6 +111,14 @@ Got a list of default packages you want installed every time you install a new N
 set --universal nvm_default_packages yarn np
 ```
 
+## `$nvm_enable_corepack`
+
+Want to enable [Corepack](https://nodejs.org/api/corepack.html) automatically every time you install a new Node version?
+
+```fish
+set --universal nvm_enable_corepack 1
+```
+
 ## `$nvm_data`
 
 Set where nvm stores Node binaries and related data. Defaults to `$XDG_DATA_HOME/nvm` (~/.local/share/nvm) if unset.

--- a/functions/nvm.fish
+++ b/functions/nvm.fish
@@ -49,6 +49,7 @@ function nvm --description "Node version manager"
             echo "       nvm_mirror               Use a mirror for downloading Node binaries"
             echo "       nvm_default_version      Set the default version for new shells"
             echo "       nvm_default_packages     Install a list of packages every time a Node version is installed"
+            echo "       nvm_enable_corepack      Enable Corepack every time a Node version is installed"
             echo "       nvm_data                 Set a custom directory for storing nvm data"
             echo "Examples:"
             echo "       nvm install latest       Install the latest version of Node"
@@ -138,6 +139,12 @@ function nvm --description "Node version manager"
                 _nvm_version_activate $ver
 
                 set --query nvm_default_packages[1] && npm install --global $silent $nvm_default_packages
+
+                if set --query nvm_enable_corepack
+                    if command --search --quiet corepack
+                        corepack enable
+                    end
+                end
             end
 
             set --query silent || printf "Now using Node %s (npm %s) %s\n" (_nvm_node_info)

--- a/tests/nvm.fish
+++ b/tests/nvm.fish
@@ -19,3 +19,11 @@
   nvm install >/dev/null 2>&1
   nvm current
 ) = v8.17.0
+
+@test "nvm install with nvm_enable_corepack" (
+  set --global nvm_enable_corepack 1
+  nvm install latest >/dev/null 2>&1
+  command --search --quiet corepack
+  set --erase nvm_enable_corepack
+  echo $status
+) = 0


### PR DESCRIPTION
## Summary
Add support for the `$nvm_enable_corepack` variable that automatically enables Corepack when installing Node.js versions.

## Changes
- **Feature**: Add `$nvm_enable_corepack` variable support
  - When set, automatically runs `corepack enable` during Node.js installation
  - Follows the same pattern as existing variables like `$nvm_default_packages`
- **Documentation**: Update help message and README.md with variable description
- **Tests**: Add test case to verify the functionality

## Usage
```fish
# Enable automatic Corepack enablement for all new Node.js installations
set --universal nvm_enable_corepack 1

# Install Node.js (Corepack will be automatically enabled)
nvm install latest
```

## Rationale
This provides a convenient way to ensure Corepack is consistently enabled across Node.js installations, similar to how `$nvm_default_packages` works for npm packages.