### PR TITLE
Document opt-in auto-use recipe in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,39 @@ Then run `nvm install` to install or `nvm use` to activate that version. Works l
 nvm install
 ```
 
+## Calling `nvm use` automatically in a directory with an `.nvmrc` file
+
+To automatically switch Node versions whenever you `cd` into a directory containing an `.nvmrc` (or `.node-version`) file, add the following to your `~/.config/fish/config.fish`:
+
+```fish
+function __nvm_auto_use --on-variable PWD
+    status is-interactive || return
+
+    set --local dir $PWD
+    set --local file
+    while test -n "$dir"
+        for name in .nvmrc .node-version
+            if test -f "$dir/$name"
+                set file "$dir/$name"
+                break
+            end
+        end
+        set --query file[1] && break
+        test "$dir" = / && break
+        set dir (path dirname "$dir")
+    end
+
+    set --query file[1] || return
+    test "$file" = "$__nvm_auto_use_file" && return
+
+    nvm use --silent && set --global __nvm_auto_use_file $file
+end
+
+__nvm_auto_use
+```
+
+The function walks up from the current directory to find the nearest `.nvmrc` or `.node-version` and activates it via `nvm use`. It remembers the last file used so it won't reactivate the same version when you move around inside the same project.
+
 ## `$nvm_mirror`
 
 Choose a mirror of the Node binaries. Default: https://nodejs.org/dist.


### PR DESCRIPTION
## Summary

Adds a README section showing how users can opt into automatic `nvm use` on `cd`, mirroring the recipe-style approach used in the upstream [nvm-sh README](https://github.com/nvm-sh/nvm#calling-nvm-use-automatically-in-a-directory-with-a-nvmrc-file).

The snippet:
- Registers a `--on-variable PWD` handler so it only runs in interactive shells
- Walks up from `$PWD` to find the nearest `.nvmrc` or `.node-version`
- Calls `nvm use --silent` when a file is found
- Caches the last activated file so it doesn't re-fire when you `cd` between subdirectories of the same project
- Runs once at config load so freshly opened shells already have the right version

## Alternative to #252

This is a documentation-only alternative to #252, which added a built-in `nvm_auto_use` variable. Keeping the behavior as a README recipe avoids growing the plugin's surface area and lets users tweak the function for their own preferences (e.g., falling back to a default version, integrating with other tools). I'll close #252 in favor of this approach.

## Test plan

- [x] Sourced the snippet in an interactive fish shell and verified that `cd`-ing into a directory with a `.nvmrc` fires the hook
- [x] Verified subsequent `cd`s within the same project are no-ops (cached file path)
- [x] Verified the hook does not fire in non-interactive shells (`fish -c '...'`)